### PR TITLE
Add waggledance.ai as an implementing Agent

### DIFF
--- a/src/app/projects-tools/page.mdx
+++ b/src/app/projects-tools/page.mdx
@@ -17,6 +17,7 @@ This is an overview of projects and tools using Agent Protocol.
 
 - [AutoGPT](https://github.com/Significant-Gravitas/Auto-GPT) - An experimental open-source attempt to make GPT-4 fully autonomous
 - [Smol developer](https://github.com/smol-ai/developer) - Your own junior developer
+- [waggledance.ai](https://github.com/agi-merge/waggle-dance) - An open-source multi-agent execution environment that implements the Agent Protocol OpenAPI spec
 
 ## Clients
 


### PR DESCRIPTION
(I think the ending newline changed bc I used Github's inline editor)

One thing to note is ALLOW_API_CLIENTS env var needs to be set up to bypass CORS restrictions. The same env var can be used to secure the API access with a Bearer token or Cookie.

For example, to allow the AutoGPT flutter frontend w/ default settings on localhost:

```
ALLOW_API_CLIENTS={"http://localhost:5000":{"source":"/api/ap/:path*","authType":"Bearer","apiKeys":{"some secure key":"admin"}}
```